### PR TITLE
[RSDK-9360]   Can't swap device_info between OAK cameras

### DIFF
--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -542,10 +542,11 @@ class Oak(Camera, Reconfigurable):
 
         attempts = 0
         while attempts < max_attempts:
-            if self.worker.running and desired_status == "running":
-                return
-            if self.worker.configured and desired_status == "configured":
-                return
+            if self.worker:
+                if self.worker.running and desired_status == "running":
+                    return
+                if self.worker.configured and desired_status == "configured":
+                    return
             attempts += 1
             await asyncio.sleep(timeout_seconds)
         raise ViamError(

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -54,6 +54,7 @@ from src.do_command_helpers import (
 )
 
 DEFAULT_IMAGE_MIMETYPE = CameraMimeType.JPEG
+RECONFIGURE_TIMEOUT_SECONDS = 0.1
 
 
 class Oak(Camera, Reconfigurable):
@@ -632,7 +633,7 @@ class OakInstanceManager(Thread):
     async def handle_reconfigures(self) -> None:
         self.logger.info("Starting reconfiguration handler loop.")
         while not self.stop_event.is_set():
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(RECONFIGURE_TIMEOUT_SECONDS)
 
             # Check for reconfiguration requests
             reqs_to_process = None

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -639,12 +639,14 @@ class OakInstanceManager(Thread):
             with self.lock:
                 if not self.reconfig_reqs:
                     continue
-                    
+
                 if not self.requests_waited:
                     self.requests_waited = True
-                    self.logger.debug("Waiting one time for more reconfiguration requests.")
+                    self.logger.debug(
+                        "Waiting one time for more reconfiguration requests."
+                    )
                     continue
-                
+
                 # Process requests after waiting one iteration
                 reqs_to_process = self.reconfig_reqs
                 self.reconfig_reqs = []

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -96,7 +96,7 @@ class Oak(Camera, Reconfigurable):
     logger: ClassVar[Logger]
     """Class scoped logger"""
     init_reconfig_manager_lock: ClassVar[Lock] = Lock()
-    """Lock for thread-safe access to initializingreconfig_manager"""
+    """Lock for thread-safe access to initializing reconfig_manager"""
     # The 'OakInstanceManager' is put in quotes because it is a forward reference.
     # This is necessary bc OakInstanceManager is not yet defined at the point of its usage.
     # Using quotes allows Python to understand that this is a type hint for a class
@@ -668,8 +668,7 @@ class OakInstanceManager(Thread):
                     # This is to ensure that when swapping device_infos, the old device is closed before
                     # the new device is opened. If we don't do this, we may encounter a race condition where
                     # the new device is opened before the old device is closed, causing the new device to fail to open.
-                    for oak, _, _ in reqs_to_process:
-                        oak._close()
+                    [oak._close() for oak, _, _ in reqs_to_process]
 
                 for oak, config, dependencies in reqs_to_process:
                     self.logger.debug(

--- a/src/components/worker/worker_manager.py
+++ b/src/components/worker/worker_manager.py
@@ -40,7 +40,7 @@ class WorkerManager(threading.Thread):
         self.worker = worker
         self.loop = None
         self.restart_atomic_bool = AtomicBoolean()
-        self._stop_event = asyncio.Event()
+        self.stop_event = asyncio.Event()
 
     def run(self):
         """
@@ -65,7 +65,7 @@ class WorkerManager(threading.Thread):
         self.worker.configure()
         await self.worker.start()
 
-        while not self._stop_event.is_set():
+        while not self.stop_event.is_set():
             self.logger.debug("Checking if worker must be restarted.")
             if self.worker.device and self.worker.device.isClosed():
                 with self.restart_atomic_bool.lock:
@@ -87,7 +87,7 @@ class WorkerManager(threading.Thread):
         """
         Thread-safe stop method to set the event to stop the singular health checking task.
         """
-        self.loop.call_soon_threadsafe(self._stop_event.set)
+        self.loop.call_soon_threadsafe(self.stop_event.set)
         self.loop.call_soon_threadsafe(self.loop.stop)
 
     async def shutdown(self):

--- a/src/config.py
+++ b/src/config.py
@@ -197,7 +197,7 @@ class OakConfig(BaseConfig):
     Base config class for OAK component models.
     """
 
-    device_info: str
+    device_info: Optional[str]
     sensors: Sensors
 
     @classmethod

--- a/src/config.py
+++ b/src/config.py
@@ -346,9 +346,13 @@ class OakFfc3PConfig(OakConfig):
     def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
         super().validate(attribute_map)
 
+        VALID_ATTRIBUTES = [
+            "device_info",
+            "camera_sensors",
+        ]
         # Validate outermost keys
         for k in attribute_map.keys():
-            if k != "camera_sensors":
+            if k not in VALID_ATTRIBUTES:
                 handle_err(f'unrecognized attribute "{k}". Please fix or remove.')
         validate_attr_type("camera_sensors", "list_value", attribute_map, True)
         cam_sensors_list = attribute_map.get("camera_sensors").list_value


### PR DESCRIPTION
[RSDK-9360](https://viam.atlassian.net/browse/RSDK-9360)


[RSDK-9360]: https://viam.atlassian.net/browse/RSDK-9360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Fixes some bugs with device_info initializing, the biggest one being swapping two device_infos.

See this comment for more context:
```
                    # If device_info is specified, close all existing Oak instances before reconfiguring
                    # This is to ensure that when swapping device_infos, the old device is closed before
                    # the new device is opened. If we don't do this, we may encounter a race condition where
                    # the new device is opened before the old device is closed, causing the new device to fail to open.
```

Basically when swapping two cameras' device infos, 90% of the time there is a race condition where both cameras close and try to acquire the other's driver before they both release, causing a hang. The fix in this PR adds a class-scoped reconfigure manager that detects if there's a device info change, and if there is, close out both cameras before reconfiguring so the drivers are free and there's no contention.