### PR TITLE
[RSDK-9453] - Add right handed system support and clean up config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following attributes are available for the `oak-d` camera component:
 | `frame_rate` | int | Optional | The frame rate the camera will capture images at. Default: `30` |
 | `device_info` | string | Optional | Physical device identifier to connect to a specific OAK camera connected to your machine. If not specified, the module will pick the first device it detects. `device_info` can be a MXID, usb port path, or IP address. [See DepthAI documentation for more details](https://docs.luxonis.com/software/depthai/examples/device_information#Device%20information). |
 | `manual_focus` | int | Optional | The manual focus value to apply to the color sensor. Sets the camera to fixed focus mode at the specified lens position. Must be between 0..255 inclusive. Default: auto focus |
-| `right_handed_system` | bool | Optional | The OAK outputs point clouds in a left-handed coordinate system by default. Viam's frame system uses right-handed coordinates. By setting to `true` all outputted PCD will have their z values negated to be compatible with right-handed systems. Default: `false` |
+| `right_handed_system` | bool | Optional | The OAK outputs point clouds in a left-handed coordinate system by default. Viam's frame system uses right-handed coordinates. By setting to `true` all outputted PCD will have their y values negated to be compatible with right-handed systems. Default: `false` |
 
 Note that higher resolutions may cause out of memory errors. See Luxonis documentation [here](https://docs.luxonis.com/projects/api/en/latest/tutorials/ram_usage/.).
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ The following attributes are available for the `oak-d` camera component:
 | `frame_rate` | int | Optional | The frame rate the camera will capture images at. Default: `30` |
 | `device_info` | string | Optional | Physical device identifier to connect to a specific OAK camera connected to your machine. If not specified, the module will pick the first device it detects. `device_info` can be a MXID, usb port path, or IP address. [See DepthAI documentation for more details](https://docs.luxonis.com/software/depthai/examples/device_information#Device%20information). |
 | `manual_focus` | int | Optional | The manual focus value to apply to the color sensor. Sets the camera to fixed focus mode at the specified lens position. Must be between 0..255 inclusive. Default: auto focus |
+| `right_handed_system` | bool | Optional | The OAK outputs point clouds in a left-handed coordinate system by default. Viam's frame system uses right-handed coordinates. By setting to `true` all outputted PCD will have their z values negated to be compatible with right-handed systems. Default: `false` |
 
 Note that higher resolutions may cause out of memory errors. See Luxonis documentation [here](https://docs.luxonis.com/projects/api/en/latest/tutorials/ram_usage/.).
 
 #### Example Full Configuration
-Copy and paste the following attributes into your arm’s JSON configuration:
+Copy and paste the following attributes into your camera's JSON configuration:
 ```json
 {
     "sensors": ["color", "depth"],

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -165,12 +165,12 @@ class Oak(Camera, Reconfigurable):
             List[str]: of dep names
         """
         if config.model == str(cls._depr_oak_agnostic_model):
-            cls.logger.warn(
+            cls.logger.warning(
                 f"The '{cls._depr_oak_agnostic_model}' is deprecated. Please switch to '{cls._oak_d_model}' or '{cls._oak_ffc_3p_model}'"
             )
             cls.model = cls._oak_d_model
         elif config.model == str(cls._depr_oak_d_model):
-            cls.logger.warn(
+            cls.logger.warning(
                 f"The '{cls._depr_oak_d_model}' is deprecated. Please switch to '{cls._oak_d_model}'"
             )
             cls.model = cls._oak_d_model
@@ -181,10 +181,11 @@ class Oak(Camera, Reconfigurable):
         else:
             raise ViamError(f"Cannot validate unrecognized model: {cls.model}")
 
+        logger = getLogger("viam-oak-validation")
         if cls.model == cls._oak_d_model:
-            return OakDConfig.validate(config.attributes.fields)
+            return OakDConfig.validate(config.attributes.fields, logger)
         else:
-            return OakFfc3PConfig.validate(config.attributes.fields)
+            return OakFfc3PConfig.validate(config.attributes.fields, logger)
 
     def reconfigure(
         self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -398,7 +398,7 @@ class Oak(Camera, Reconfigurable):
         """
         # Validation
         if not self.oak_cfg.sensors.stereo_pair:
-            details = "Cannot process PCD. OAK camera not configured for stereo depth outputs. See README for details"
+            details = "Cannot process PCD. OAK camera not configured for stereo depth outputs. Please see module docs in app configuration card."
             raise MethodNotAllowed(method_name="get_point_cloud", details=details)
 
         await self._wait_for_worker()

--- a/src/components/worker/worker.py
+++ b/src/components/worker/worker.py
@@ -518,9 +518,9 @@ class Worker:
         pc_obj = msg["pcl"]
         points = pc_obj.getPoints().astype(np.float64)
 
-        # Convert to right-handed system by negating z if configured
+        # Convert to right-handed system by negating y if configured
         if isinstance(self.cfg, OakDConfig) and self.cfg.right_handed_system:
-            points[:, 2] = -points[:, 2]
+            points[:, 1] = -points[:, 1]
 
         if points.nbytes > MAX_GRPC_MESSAGE_BYTE_COUNT:
             pc_output = self._downsample_pcd(points, points.nbytes)

--- a/src/components/worker/worker.py
+++ b/src/components/worker/worker.py
@@ -24,7 +24,7 @@ from numpy.typing import NDArray
 import numpy as np
 
 from src.components.helpers.shared import CapturedData
-from src.config import OakConfig, YDNConfig, Sensor
+from src.config import OakConfig, OakDConfig, YDNConfig, Sensor
 
 DIMENSIONS_TO_MONO_RES = {
     (1280, 800): dai.MonoCameraProperties.SensorResolution.THE_800_P,
@@ -517,6 +517,11 @@ class Worker:
 
         pc_obj = msg["pcl"]
         points = pc_obj.getPoints().astype(np.float64)
+
+        # Convert to right-handed system by negating z if configured
+        if isinstance(self.cfg, OakDConfig) and self.cfg.right_handed_system:
+            points[:, 2] = -points[:, 2]
+
         if points.nbytes > MAX_GRPC_MESSAGE_BYTE_COUNT:
             pc_output = self._downsample_pcd(points, points.nbytes)
         else:

--- a/src/components/worker/worker.py
+++ b/src/components/worker/worker.py
@@ -137,7 +137,7 @@ class Worker:
         user_wants_pc: bool,
     ) -> None:
         self.logger = getLogger(oak_config.name)
-        self.logger.info("Initializing worker.")
+        self.logger.warning("Initializing worker.")
         self.cfg = oak_config
         self.ydn_configs = ydn_configs
         self.user_wants_pc = user_wants_pc
@@ -584,7 +584,7 @@ class Worker:
 
     def _downsample_pcd(self, arr: NDArray, byte_count: int) -> NDArray:
         factor = byte_count // MAX_GRPC_MESSAGE_BYTE_COUNT + 1
-        self.logger.warn(
+        self.logger.warning(
             f"PCD bytes ({byte_count}) > max gRPC bytes count ({MAX_GRPC_MESSAGE_BYTE_COUNT}). Subsampling by 1/{factor}."
         )
         if arr.ndim == 2:

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 import os
+from logging import Logger
 from typing import ClassVar, Dict, List, Literal, Mapping, Optional, Tuple
 
 from google.protobuf.struct_pb2 import Value
@@ -167,7 +168,7 @@ class BaseConfig:
         self.name = name
 
     @classmethod
-    def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
+    def validate(cls, attribute_map: Mapping[str, Value], logger: Logger) -> List[str]:
         """
         Equivalent to the module validate() method but specific to a model's specific config.
 
@@ -199,7 +200,7 @@ class OakConfig(BaseConfig):
     sensors: Sensors
 
     @classmethod
-    def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
+    def validate(cls, attribute_map: Mapping[str, Value], logger: Logger) -> List[str]:
         # Validate shared OAK attributes such as "device_info"
         validate_attr_type("device_info", "string_value", attribute_map)
         device_info = attribute_map.get(key="device_info", default=None)
@@ -268,14 +269,14 @@ class OakDConfig(OakConfig):
         self.sensors = Sensors(sensor_list)
 
     @classmethod
-    def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
-        super().validate(attribute_map)
+    def validate(cls, attribute_map: Mapping[str, Value], logger: Logger) -> List[str]:
+        super().validate(attribute_map, logger)
 
         # Validate outermost keys
-        for attribute in attribute_map.keys():
-            if attribute not in cls.VALID_ATTRIBUTES:
-                handle_err(
-                    f'"{attribute}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
+        for k in attribute_map.keys():
+            if k not in cls.VALID_ATTRIBUTES:
+                logger.warning(
+                    f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 
         # Check sensors is valid
@@ -357,13 +358,13 @@ class OakFfc3PConfig(OakConfig):
     VALID_ATTRIBUTES: ClassVar[List[str]] = ["device_info", "camera_sensors"]
 
     @classmethod
-    def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
-        super().validate(attribute_map)
+    def validate(cls, attribute_map: Mapping[str, Value], logger: Logger) -> List[str]:
+        super().validate(attribute_map, logger)
 
         # Validate outermost keys
         for k in attribute_map.keys():
             if k not in cls.VALID_ATTRIBUTES:
-                handle_err(
+                logger.warning(
                     f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 
@@ -523,13 +524,13 @@ class YDNConfig(BaseConfig):
         return self
 
     @classmethod
-    def validate(cls, attribute_map: Mapping[str, Value]) -> List[str]:
-        super().validate(attribute_map)
+    def validate(cls, attribute_map: Mapping[str, Value], logger: Logger) -> List[str]:
+        super().validate(attribute_map, logger)
 
         # Validate outermost keys
         for k in attribute_map.keys():
-            if not k in cls.VALID_ATTRIBUTES:
-                handle_err(
+            if k not in cls.VALID_ATTRIBUTES:
+                logger.warning(
                     f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 

--- a/src/config.py
+++ b/src/config.py
@@ -128,7 +128,7 @@ def validate_attr_type(
     if value is None:
         if is_required_attr:
             handle_err(
-                f'"{attribute}" is a required field, but was not detected. Please see README for details.'
+                f'"{attribute}" is a required field, but was not detected. Please see module docs in app configuration card.'
             )
         else:
             return
@@ -275,7 +275,7 @@ class OakDConfig(OakConfig):
         for attribute in attribute_map.keys():
             if attribute not in cls.VALID_ATTRIBUTES:
                 handle_err(
-                    f'"{attribute}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see README for details.'
+                    f'"{attribute}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 
         # Check sensors is valid
@@ -364,7 +364,7 @@ class OakFfc3PConfig(OakConfig):
         for k in attribute_map.keys():
             if k not in cls.VALID_ATTRIBUTES:
                 handle_err(
-                    f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see README for details.'
+                    f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 
         # Validate "camera_sensors"
@@ -530,7 +530,7 @@ class YDNConfig(BaseConfig):
         for k in attribute_map.keys():
             if not k in cls.VALID_ATTRIBUTES:
                 handle_err(
-                    f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see README for details.'
+                    f'"{k}" is not a valid attribute i.e. not in {cls.VALID_ATTRIBUTES}. Please see module docs in app configuration card.'
                 )
 
         # Validate "input_source"

--- a/src/services/yolo_detection_network.py
+++ b/src/services/yolo_detection_network.py
@@ -106,7 +106,7 @@ class YoloDetectionNetwork(Vision, Reconfigurable):
                     await self.cam.do_command(command=configure_cmd)
                     self.pipeline_configured = True
                 except Exception as e:
-                    self.logger.warn(
+                    self.logger.warning(
                         f"Error in do_command: {e}. Trying to configure via do_command again..."
                     )
                     attempts += 1
@@ -130,7 +130,7 @@ class YoloDetectionNetwork(Vision, Reconfigurable):
         timeout: Optional[float] = None,
     ) -> CaptureAllResult:
         if camera_name == "" or camera_name is None:
-            self.logger.warn(
+            self.logger.warning(
                 f"camera_name arg was unspecified. Defaulting to '{self.cam_name}'"
             )
         elif camera_name != self.cam_name:
@@ -167,7 +167,7 @@ class YoloDetectionNetwork(Vision, Reconfigurable):
         extra: Mapping[str, Any],
         timeout: float,
     ) -> List[Detection]:
-        self.logger.warn(
+        self.logger.warning(
             "WARNING! get_detections calls get_detections_from_camera under the hood. Use only for debugging purposes. Your image will be ignored."
         )
         return await self.get_detections_from_camera("", extra=None, timeout=None)
@@ -176,7 +176,7 @@ class YoloDetectionNetwork(Vision, Reconfigurable):
         self, camera_name: str, *, extra: Mapping[str, Any], timeout: float
     ) -> List[Detection]:
         if camera_name == "" or camera_name is None:
-            self.logger.warn(
+            self.logger.warning(
                 f"camera_name arg was unspecified. Defaulting to '{self.cam_name}'"
             )
         elif camera_name != self.cam_name:

--- a/src/services/yolo_detection_network.py
+++ b/src/services/yolo_detection_network.py
@@ -61,7 +61,8 @@ class YoloDetectionNetwork(Vision, Reconfigurable):
 
     @classmethod
     def validate(cls, config: ServiceConfig) -> Sequence[str]:
-        return YDNConfig.validate(config.attributes.fields)
+        logger = getLogger("viam-ydn-validation")
+        return YDNConfig.validate(config.attributes.fields, logger)
 
     def reconfigure(
         self, config: ServiceConfig, dependencies: Mapping[ResourceName, ResourceBase]

--- a/tests/test_oak_d.py
+++ b/tests/test_oak_d.py
@@ -6,14 +6,6 @@ from src.components.oak import Oak
 from tests.helpers import make_component_config
 
 
-invalid_attribute_name = (
-    make_component_config({
-        "sensors": ["color"],
-        "foo": "bar"
-    }, "viam:luxonis:oak-d"),
-    "is not a valid attribute"
-)
-
 sensors_not_present = (
     make_component_config(dict(), "viam:luxonis:oak-d"),
     'a "sensors" attribute of a list of sensor(s)'
@@ -185,7 +177,6 @@ right_handed_system_not_bool = (
 )
 
 configs_and_msgs = [
-    invalid_attribute_name,
     sensors_not_present,
     sensors_is_not_list,
     sensors_is_empty_list,

--- a/tests/test_oak_d.py
+++ b/tests/test_oak_d.py
@@ -176,6 +176,14 @@ manual_focus_not_integer = (
     '"manual_focus" must be an integer'
 )
 
+right_handed_system_not_bool = (
+    make_component_config({
+        "sensors": ["color", "depth"],
+        "right_handed_system": "true"
+    }, "viam:luxonis:oak-d"),
+    "attribute must be a bool_value"
+)
+
 configs_and_msgs = [
     invalid_attribute_name,
     sensors_not_present,
@@ -198,7 +206,8 @@ configs_and_msgs = [
     wrong_device_info_type,
     manual_focus_set_for_non_color,
     manual_focus_out_of_range,
-    manual_focus_not_integer
+    manual_focus_not_integer,
+    right_handed_system_not_bool
 ]
 
 full_correct_config = make_component_config({
@@ -217,7 +226,7 @@ minimal_correct_config = make_component_config({
 def test_validate_errors_parameterized(config, msg):
     with pytest.raises(ValidationError) as exc_info:
         Oak.validate(config)
-        assert exc_info.type == ValidationError
+    assert exc_info.type == ValidationError
     assert msg in str(exc_info.value)
 
 def test_validate_no_errors():
@@ -225,5 +234,5 @@ def test_validate_no_errors():
         Oak.validate(full_correct_config)
         Oak.validate(minimal_correct_config)
     except Exception as e:
-        s = (f"Expected a correct config to not raise {type(e)} during validation, yet it did :,)")
+        s = (f"Expected a correct config to not raise {type(e)} during validation, yet it did: {e}")
         pytest.fail(reason=s)

--- a/tests/test_oak_ffc_3p.py
+++ b/tests/test_oak_ffc_3p.py
@@ -72,7 +72,7 @@ camera_sensors_wrong_type_config = (
     "each cam_sensor must be a Struct mapping"
 )
 
-unrecognized_outer_attr_config = (
+invalid_outer_attr_config = (
     make_component_config({
         "camera_sensors": [
             {
@@ -84,9 +84,9 @@ unrecognized_outer_attr_config = (
                 "interleaved": False,
             },
         ],
-        "unrecognized_attribute": True
+        "invalid_attribute": True
     }, "viam:luxonis:oak-ffc-3p"),
-    "unrecognized attribute"
+    "is not a valid attribute"
 )
 
 two_cams_one_socket_config = (
@@ -413,7 +413,7 @@ incorrect_configs_and_errs = [
     empty_sensors_config,
     over_three_sensors_config,
     camera_sensors_wrong_type_config,
-    unrecognized_outer_attr_config,
+    invalid_outer_attr_config,
     two_cams_one_socket_config,
     one_mono_config,
     three_mono_config,
@@ -438,7 +438,7 @@ incorrect_configs_and_errs = [
 def test_invalid_configs(invalid_config, msg):
     with pytest.raises(ValidationError) as exc_info:
         Oak.validate(invalid_config)
-        assert exc_info.type == ValidationError
+    assert exc_info.type == ValidationError
     assert msg in str(exc_info.value)
 
 ### TEST VALID CONFIGS

--- a/tests/test_oak_ffc_3p.py
+++ b/tests/test_oak_ffc_3p.py
@@ -229,7 +229,7 @@ missing_width_config = (
             },
         ],
     }, "viam:luxonis:oak-ffc-3p"),
-   '"width_px" is a required field, but was not detected. Please see README for details.'
+   '"width_px" is a required field, but was not detected. Please see module docs in app configuration card.'
 )
 
 missing_height_config = (
@@ -244,7 +244,7 @@ missing_height_config = (
             },
         ],
     }, "viam:luxonis:oak-ffc-3p"),
-   '"height_px" is a required field, but was not detected. Please see README for details.'
+   '"height_px" is a required field, but was not detected. Please see module docs in app configuration card.'
 )
 
 dimension_not_num_type_config = (

--- a/tests/test_oak_ffc_3p.py
+++ b/tests/test_oak_ffc_3p.py
@@ -72,23 +72,6 @@ camera_sensors_wrong_type_config = (
     "each cam_sensor must be a Struct mapping"
 )
 
-invalid_outer_attr_config = (
-    make_component_config({
-        "camera_sensors": [
-            {
-                "socket": "cam_a",
-                "type": "depth",
-                "width_px": 512,
-                "height_px": 512,
-                "frame_rate": 30,
-                "interleaved": False,
-            },
-        ],
-        "invalid_attribute": True
-    }, "viam:luxonis:oak-ffc-3p"),
-    "is not a valid attribute"
-)
-
 two_cams_one_socket_config = (
     make_component_config({
         "camera_sensors": [
@@ -413,7 +396,6 @@ incorrect_configs_and_errs = [
     empty_sensors_config,
     over_three_sensors_config,
     camera_sensors_wrong_type_config,
-    invalid_outer_attr_config,
     two_cams_one_socket_config,
     one_mono_config,
     three_mono_config,

--- a/tests/test_ydn.py
+++ b/tests/test_ydn.py
@@ -281,7 +281,7 @@ minimal_correct_config = make_service_config({
 def test_validate_errors_parameterized(config, msg):
     with pytest.raises(ValidationError) as exc_info:
         YoloDetectionNetwork.validate(config)
-        assert exc_info.type == ValidationError
+    assert exc_info.type == ValidationError
     assert msg in str(exc_info.value)
 
 def test_validate_no_errors():
@@ -298,5 +298,5 @@ def test_validate_no_errors():
         deps2 = YoloDetectionNetwork.validate(minimal_correct_config)
         check_deps(deps2)
     except Exception as e:
-        s = (f"Expected a correct config to not raise {type(e)} during validation/reconfiguration, yet it did :,)")
+        s = (f"Expected a correct config to not raise {type(e)} during validation/reconfiguration, yet it did: {e}")
         pytest.fail(reason=s)


### PR DESCRIPTION
Motion wants right handed coordinates. DepthAI outputs left handed. We flip the outputted PCD data y-axis when the new non-breaking additive config attribute is set to true. I also cleaned up some of the config handling and tests.

### Testing

- [x] Added new unit test for new attribute
- [x] Verified integration tests pass
- [x] Verified that by default it is outputting left-hand, and when new attr is toggled, it outputs right-handed by seeing the resultant PCD flipped on the y-axis
![Screenshot 2025-02-25 at 5 07 01 PM](https://github.com/user-attachments/assets/5a44f0f5-5018-41ae-aae7-9d8c855592c1)
Without `right_handed_system` enabled ^
![Screenshot 2025-02-25 at 5 09 11 PM](https://github.com/user-attachments/assets/056d7791-3988-4b83-9c18-e43892326649)
With `right_handed_system` enabled^