### PR TITLE
[RSDK-10114] - Add non-breaking `point_cloud_enabled` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following attributes are available for the `oak-d` camera component:
 | `device_info` | string | Optional | Physical device identifier to connect to a specific OAK camera connected to your machine. If not specified, the module will pick the first device it detects. `device_info` can be a MXID, usb port path, or IP address. [See DepthAI documentation for more details](https://docs.luxonis.com/software/depthai/examples/device_information#Device%20information). |
 | `manual_focus` | int | Optional | The manual focus value to apply to the color sensor. Sets the camera to fixed focus mode at the specified lens position. Must be between 0..255 inclusive. Default: auto focus |
 | `right_handed_system` | bool | Optional | The OAK outputs point clouds in a left-handed coordinate system by default. Viam's frame system uses right-handed coordinates. By setting to `true` all outputted PCD will have their y values negated to be compatible with right-handed systems. Default: `false` |
+| `point_cloud_enabled` | bool | Optional | Whether or not to enable point cloud functionality. Note that this is CPU intensive and should only be used when PCD is necessary. Default: `false` |
 
 Note that higher resolutions may cause out of memory errors. See Luxonis documentation [here](https://docs.luxonis.com/projects/api/en/latest/tutorials/ram_usage/.).
 
@@ -72,6 +73,8 @@ Copy and paste the following attributes into your camera's JSON configuration:
     "width_px": 416,
     "height_px": 416,
     "frame_rate": 30,
+    "right_handed_system": true,
+    "point_cloud_enabled": false,
     "device_info": "<mxid-or-ip-address-or-usb-port-name>"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The following attributes are available for the `oak-d` camera component:
 | `device_info` | string | Optional | Physical device identifier to connect to a specific OAK camera connected to your machine. If not specified, the module will pick the first device it detects. `device_info` can be a MXID, usb port path, or IP address. [See DepthAI documentation for more details](https://docs.luxonis.com/software/depthai/examples/device_information#Device%20information). |
 | `manual_focus` | int | Optional | The manual focus value to apply to the color sensor. Sets the camera to fixed focus mode at the specified lens position. Must be between 0..255 inclusive. Default: auto focus |
 | `right_handed_system` | bool | Optional | The OAK outputs point clouds in a left-handed coordinate system by default. Viam's frame system uses right-handed coordinates. By setting to `true` all outputted PCD will have their y values negated to be compatible with right-handed systems. Default: `false` |
-| `point_cloud_enabled` | bool | Optional | Whether or not to enable point cloud functionality. Note that this is CPU intensive and should only be used when PCD is necessary. Default: `false` |
+| `point_cloud_enabled` | bool | Optional | Whether or not to enable point cloud functionality. Note that this is CPU intensive and should only be used when PCD is necessary. Moreover, at least "depth" must be requested in the `sensors` array. "color" must also
+be requested if color data is needed for outputted PCD. Default: `false` |
 
 Note that higher resolutions may cause out of memory errors. See Luxonis documentation [here](https://docs.luxonis.com/projects/api/en/latest/tutorials/ram_usage/.).
 

--- a/src/components/oak.py
+++ b/src/components/oak.py
@@ -404,6 +404,8 @@ class Oak(Camera, Reconfigurable):
                 details="attribute 'point_cloud_enabled' is unspecified or set to false. Please set to true in app configuration card.",
             )
 
+        await self._wait_for_worker()
+
         try:
             pcd_obj = await self.worker.get_pcd()
             arr = pcd_obj.np_array

--- a/src/components/worker/worker.py
+++ b/src/components/worker/worker.py
@@ -515,10 +515,6 @@ class Worker:
             raise ViamError(
                 "Error getting PCD: point_cloud_enabled is not enabled for current OAK camera."
             )
-        if not self.depth_queue:
-            raise ViamError(
-                "Error getting PCD: depth frame queue not configured for current OAK camera."
-            )
 
         msg: Optional[dai.MessageGroup] = None
         while msg is None and self.should_exec:

--- a/src/config.py
+++ b/src/config.py
@@ -223,6 +223,7 @@ class OakDConfig(OakConfig):
         "frame_rate",
         "manual_focus",
         "right_handed_system",
+        "point_cloud_enabled",
     ]
 
     height_px: int
@@ -241,6 +242,9 @@ class OakDConfig(OakConfig):
         manual_focus = int(self.attribute_map["manual_focus"].number_value) or None
         self.right_handed_system = (
             self.attribute_map["right_handed_system"].bool_value or False
+        )
+        self.point_cloud_enabled = (
+            self.attribute_map["point_cloud_enabled"].bool_value or False
         )
 
         sensor_list = []
@@ -347,6 +351,8 @@ class OakDConfig(OakConfig):
         # Validate right_handed_system
         validate_attr_type("right_handed_system", "bool_value", attribute_map, False)
 
+        # Validate point_cloud_enabled
+        validate_attr_type("point_cloud_enabled", "bool_value", attribute_map, False)
         return []  # no deps
 
 

--- a/tests/test_oak_d.py
+++ b/tests/test_oak_d.py
@@ -176,6 +176,14 @@ right_handed_system_not_bool = (
     "attribute must be a bool_value"
 )
 
+point_cloud_enabled_not_bool = (
+    make_component_config({
+        "sensors": ["color", "depth"],
+        "point_cloud_enabled": "true"
+    }, "viam:luxonis:oak-d"),
+    "attribute must be a bool_value"
+)
+
 configs_and_msgs = [
     sensors_not_present,
     sensors_is_not_list,
@@ -198,7 +206,8 @@ configs_and_msgs = [
     manual_focus_set_for_non_color,
     manual_focus_out_of_range,
     manual_focus_not_integer,
-    right_handed_system_not_bool
+    right_handed_system_not_bool,
+    point_cloud_enabled_not_bool
 ]
 
 full_correct_config = make_component_config({


### PR DESCRIPTION
I think it is better design to add an attribute to configure the pipeline for PCD rather than dynamically reconfiguring when a user calls `get_point_cloud` to do so.